### PR TITLE
update schema to v2.8.0

### DIFF
--- a/RELEASENOTE.md
+++ b/RELEASENOTE.md
@@ -1,5 +1,11 @@
 # RELEASE NOTE
 
+## release 日期 2022-05-04
+
+v2.8.0 release
+
+- optimize: VlanApi: [VmVlanCreationParams], [VmVlanUpdationParamsData], [ManagementVlanUpdationParamsData] 限制 `VlanId` 范围为 0~4095
+
 ## release 日期 2022-03-22
 
 v2.7.0 release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudtower-node-sdk",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "cloudtower operation api",
   "main": "lib/index.js",
   "typings": "typings/index.d.ts",

--- a/src/generated/data-contracts.ts
+++ b/src/generated/data-contracts.ts
@@ -15365,7 +15365,7 @@ export interface DataPoint {
   /** @format double */
   v?: number | null;
 
-  /** @format double */
+  /** @format int64 */
   t: number;
   __typename?: "DataPoint";
 }
@@ -20514,16 +20514,21 @@ export interface WithTaskVlan {
   data: Vlan;
 }
 
+/**
+ * @format int32
+ * @min 0
+ * @max 4095
+ */
+export type VlanId = number;
+
 export interface VmVlanCreationParams {
   vds_id: string;
-
-  /** @format int32 */
-  vlan_id: number;
+  vlan_id: VlanId;
   name: string;
 }
 
 export interface VmVlanUpdationParams {
-  data: { vlan_id?: number; name?: string };
+  data: { vlan_id?: VlanId; name?: string };
   where: VlanWhereInput;
 }
 
@@ -20537,7 +20542,7 @@ export interface ManagementVlanUpdationParams {
     extra_ip?: ExtraIp[];
     subnetmask?: string;
     gateway_ip?: string;
-    vlan_id?: number;
+    vlan_id?: VlanId;
   };
   where: VlanWhereInput;
 }
@@ -20547,7 +20552,7 @@ export interface MigrationVlanUpdationParams {
     extra_ip?: ExtraIp[];
     subnetmask?: string;
     gateway_ip?: string;
-    vlan_id?: number;
+    vlan_id?: VlanId;
   };
   where: VlanWhereInput;
 }


### PR DESCRIPTION
## release 日期 2022-05-04

v2.8.0 release

- optimize: VlanApi: [VmVlanCreationParams], [VmVlanUpdationParamsData], [ManagementVlanUpdationParamsData] 限制 `VlanId` 范围为 0~4095